### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+teckit (2.5.11+ds1-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + teckit: Drop versioned constraint on texlive-binaries in Replaces.
+    + teckit: Drop versioned constraint on texlive-binaries in Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 27 Feb 2022 18:57:39 -0000
+
 teckit (2.5.11+ds1-1) unstable; urgency=medium
 
   * New upstream version 2.5.11+ds1

--- a/debian/control
+++ b/debian/control
@@ -21,8 +21,6 @@ Package: teckit
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
          libteckit0 (= ${binary:Version})
-Replaces: texlive-binaries (<< 2018.20180907.48586-3~)
-Breaks: texlive-binaries (<< 2018.20180907.48586-3~)
 Multi-Arch: foreign
 Description: Custom legacy encoding conversion tools for plain text files
  TECkit is a toolkit for encoding conversions. It offers a simple format for


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/teckit/03332fcd-08e2-46f1-80f5-4c35eeb53ee4.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*libteckit-dev\*\*

No differences were encountered between the control files of package \*\*libteckit0\*\*

No differences were encountered between the control files of package \*\*libteckit0-dbgsym\*\*
### Control files of package teckit: lines which differ (wdiff format)
* [-Breaks: texlive-binaries (<< 2018.20180907.48586-3~)-]
* [-Replaces: texlive-binaries (<< 2018.20180907.48586-3~)-]

No differences were encountered between the control files of package \*\*teckit-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/03332fcd-08e2-46f1-80f5-4c35eeb53ee4/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/03332fcd-08e2-46f1-80f5-4c35eeb53ee4/diffoscope)).
